### PR TITLE
fix(endpoint): omit default HTTPS port (443) from generated URL

### DIFF
--- a/include/savanna/endpoint.hpp
+++ b/include/savanna/endpoint.hpp
@@ -60,7 +60,7 @@ namespace savanna
 			std::string new_url;
 			new_url += scheme() + "://";
 			new_url += host();
-			if (port() != 80) {
+			if (port() != 80 && port() != 443) {
 				new_url += ":" + std::to_string(port());
 			}
 			new_url += build_path();


### PR DESCRIPTION
uild_url_str() previously appended ":port" whenever the port differed from 80, so HTTPS requests produced URLs like https://host:443/path. When this absolute-form URL is used as the HTTP request-target, intermediaries (e.g. AWS S3) may rebuild the canonical Host header from the request-line, ending up with "Host: host:443" in their canonical headers.